### PR TITLE
Upgrade Spring Boot 3.5.4 to 3.5.9 and remove unused javax.swing imports

### DIFF
--- a/section-03-registration/01-jobportal-registration-project-setup/pom.xml
+++ b/section-03-registration/01-jobportal-registration-project-setup/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-03-registration/02-jobportal-registration-add-project-template-files/pom.xml
+++ b/section-03-registration/02-jobportal-registration-add-project-template-files/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-03-registration/03-jobportal-registration-add-registration-database-entities/pom.xml
+++ b/section-03-registration/03-jobportal-registration-add-registration-database-entities/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-03-registration/04-jobportal-registration-repositories-and-controllers/pom.xml
+++ b/section-03-registration/04-jobportal-registration-repositories-and-controllers/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-03-registration/05-jobportal-registration-register-new-user/pom.xml
+++ b/section-03-registration/05-jobportal-registration-register-new-user/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-03-registration/06-jobportal-registration-user-profiles-for-recruiter-and-job-seeker/pom.xml
+++ b/section-03-registration/06-jobportal-registration-user-profiles-for-recruiter-and-job-seeker/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-03-registration/07-jobportal-registration-add-skills-and-update-profiles/pom.xml
+++ b/section-03-registration/07-jobportal-registration-add-skills-and-update-profiles/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-04-login-logout/01-job-portal-login-logout-basic-setup/pom.xml
+++ b/section-04-login-logout/01-job-portal-login-logout-basic-setup/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/pom.xml
+++ b/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -11,8 +11,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/pom.xml
+++ b/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/pom.xml
+++ b/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-04-login-logout/05-job-portal-login-logout-request-mappings/pom.xml
+++ b/section-04-login-logout/05-job-portal-login-logout-request-mappings/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/pom.xml
+++ b/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/pom.xml
+++ b/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/pom.xml
+++ b/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-06-recruiter-post-new-job/01-recruiter-post-new-job/pom.xml
+++ b/section-06-recruiter-post-new-job/01-recruiter-post-new-job/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-06-recruiter-post-new-job/01-recruiter-post-new-job/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-06-recruiter-post-new-job/01-recruiter-post-new-job/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/pom.xml
+++ b/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/pom.xml
+++ b/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-08-job-candidate-profile/01-job-candidate-profile/pom.xml
+++ b/section-08-job-candidate-profile/01-job-candidate-profile/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-08-job-candidate-profile/01-job-candidate-profile/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-08-job-candidate-profile/01-job-candidate-profile/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/pom.xml
+++ b/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/pom.xml
+++ b/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-11-download-candidate-resume/01-download-candidate-resume/pom.xml
+++ b/section-11-download-candidate-resume/01-download-candidate-resume/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-11-download-candidate-resume/01-download-candidate-resume/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-11-download-candidate-resume/01-download-candidate-resume/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 

--- a/section-12-global-search/01-global-search/pom.xml
+++ b/section-12-global-search/01-global-search/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.9</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.luv2code</groupId>

--- a/section-12-global-search/01-global-search/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
+++ b/section-12-global-search/01-global-search/src/main/java/com/luv2code/jobportal/config/WebSecurityConfig.java
@@ -12,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import javax.swing.*;
-
 @Configuration
 public class WebSecurityConfig {
 


### PR DESCRIPTION
## Summary
- Upgraded Spring Boot from 3.5.4 to 3.5.9 across all 23 projects
- Removed unused `import javax.swing.*;` from 14 WebSecurityConfig.java files

## Changes
- **23 pom.xml files**: Updated Spring Boot parent version from 3.5.4 to 3.5.9
- **14 WebSecurityConfig.java files**: Removed incorrect javax.swing import

## Testing
- All projects compile successfully
- No new compilation errors or warnings introduced
- Java version remains at 21 (unchanged)