### PR TITLE
Upgrade Java 21 to Java 25

### DIFF
--- a/section-03-registration/01-jobportal-registration-project-setup/pom.xml
+++ b/section-03-registration/01-jobportal-registration-project-setup/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-03-registration/02-jobportal-registration-add-project-template-files/pom.xml
+++ b/section-03-registration/02-jobportal-registration-add-project-template-files/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-03-registration/03-jobportal-registration-add-registration-database-entities/pom.xml
+++ b/section-03-registration/03-jobportal-registration-add-registration-database-entities/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-03-registration/04-jobportal-registration-repositories-and-controllers/pom.xml
+++ b/section-03-registration/04-jobportal-registration-repositories-and-controllers/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-03-registration/05-jobportal-registration-register-new-user/pom.xml
+++ b/section-03-registration/05-jobportal-registration-register-new-user/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-03-registration/06-jobportal-registration-user-profiles-for-recruiter-and-job-seeker/pom.xml
+++ b/section-03-registration/06-jobportal-registration-user-profiles-for-recruiter-and-job-seeker/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-03-registration/07-jobportal-registration-add-skills-and-update-profiles/pom.xml
+++ b/section-03-registration/07-jobportal-registration-add-skills-and-update-profiles/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-04-login-logout/01-job-portal-login-logout-basic-setup/pom.xml
+++ b/section-04-login-logout/01-job-portal-login-logout-basic-setup/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/pom.xml
+++ b/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/pom.xml
+++ b/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/pom.xml
+++ b/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-04-login-logout/05-job-portal-login-logout-request-mappings/pom.xml
+++ b/section-04-login-logout/05-job-portal-login-logout-request-mappings/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/pom.xml
+++ b/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/pom.xml
+++ b/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/pom.xml
+++ b/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-06-recruiter-post-new-job/01-recruiter-post-new-job/pom.xml
+++ b/section-06-recruiter-post-new-job/01-recruiter-post-new-job/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/pom.xml
+++ b/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/pom.xml
+++ b/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-08-job-candidate-profile/01-job-candidate-profile/pom.xml
+++ b/section-08-job-candidate-profile/01-job-candidate-profile/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/pom.xml
+++ b/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/pom.xml
+++ b/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-11-download-candidate-resume/01-download-candidate-resume/pom.xml
+++ b/section-11-download-candidate-resume/01-download-candidate-resume/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/section-12-global-search/01-global-search/pom.xml
+++ b/section-12-global-search/01-global-search/pom.xml
@@ -14,7 +14,7 @@
 	<name>jobportal</name>
 	<description>Job Portal</description>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
## Summary
Upgraded Java from version 21 to 25 (LTS) across all 23 projects while maintaining Spring Boot 3.5.9.

## Changes
- Updated `<java.version>` from 21 to 25 in all pom.xml files
- 23 projects affected across sections 03-12

## Compatibility
- Java 25: LTS release (September 16, 2025) with 8+ years Oracle support
- Spring Boot 3.5.9: Fully compatible with Java 25
- All projects compile successfully with Java 25