### PR TITLE
Add parallel build GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,276 @@
+name: Build
+
+on:
+  push:
+    branches: [ main, master ]
+
+jobs:
+  build-03-registration:
+    name: "Section 03: Registration (7 projects)"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 03: Registration"
+        find section-03-registration -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 03 completed successfully"
+
+  build-04-login-logout:
+    name: "Section 04: Login Logout (5 projects)"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 04: Login Logout"
+        find section-04-login-logout -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 04 completed successfully"
+
+  build-05-recruiter-profile:
+    name: "Section 05: Recruiter Profile (3 projects)"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 05: Recruiter Profile"
+        find section-05-recruiter-profile -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 05 completed successfully"
+
+  build-06-recruiter-post-new-job:
+    name: "Section 06: Recruiter Post New Job"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 06: Recruiter Post New Job"
+        find section-06-recruiter-post-new-job -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 06 completed successfully"
+
+  build-07-recruiter-dashboard:
+    name: "Section 07: Recruiter Dashboard (2 projects)"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 07: Recruiter Dashboard"
+        find section-07-recruiter-dashboard -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 07 completed successfully"
+
+  build-08-job-candidate-profile:
+    name: "Section 08: Job Candidate Profile"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 08: Job Candidate Profile"
+        find section-08-job-candidate-profile -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 08 completed successfully"
+
+  build-09-job-candidate-dashboard-and-apply-for-job:
+    name: "Section 09: Job Candidate Dashboard and Apply for Job"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 09: Job Candidate Dashboard and Apply for Job"
+        find section-09-job-candidate-dashboard-and-apply-for-job -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 09 completed successfully"
+
+  build-10-job-candidate-save-a-job:
+    name: "Section 10: Job Candidate Save a Job"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 10: Job Candidate Save a Job"
+        find section-10-job-candidate-save-a-job -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 10 completed successfully"
+
+  build-11-download-candidate-resume:
+    name: "Section 11: Download Candidate Resume"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 11: Download Candidate Resume"
+        find section-11-download-candidate-resume -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 11 completed successfully"
+
+  build-12-global-search:
+    name: "Section 12: Global Search"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
+      with:
+        java-version: '25'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build all projects in section
+      run: |
+        set -e
+        echo "Building Section 12: Global Search"
+        find section-12-global-search -name pom.xml -not -path "*/target/*" | sort | while read pom; do
+          echo "Building $(dirname $pom)"
+          mvn clean compile -B -q -f "$pom" || {
+            echo "Failed to compile $pom"
+            exit 1
+          }
+        done
+        echo "Section 12 completed successfully"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spring Boot 4 Project: Build a Job Portal Web Application
 
+![Build Status](https://github.com/darbyluv2code/spring-boot-project-job-portal-web-app/actions/workflows/build.yml/badge.svg)
+
 Source code for the course: [Spring Boot 4 Project: Build a Job Portal Web Application](http://www.luv2code.com/spring-boot-3-project-job-portal-web-app-github)
 
 If you have questions or need tech support, post your questions to the [classroom discussion forum](https://www.udemy.com/course/spring-boot-project-job-portal-web-app/learn/v4/questions).


### PR DESCRIPTION
Adds GitHub Actions workflow with 10 parallel jobs (one per section) for faster builds and includes build status badge in README.

This workflow:
- Compiles all 23 projects across 10 sections in parallel
- Uses Java 25 with Temurin distribution
- Includes Maven dependency caching for performance
- Adds build status badge to README for visibility

Each job builds all projects in one section independently, reducing overall build time.