### PR TITLE
Add .gitattributes to all Maven projects

### DIFF
--- a/section-03-registration/01-jobportal-registration-project-setup/.gitattributes
+++ b/section-03-registration/01-jobportal-registration-project-setup/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-03-registration/02-jobportal-registration-add-project-template-files/.gitattributes
+++ b/section-03-registration/02-jobportal-registration-add-project-template-files/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-03-registration/03-jobportal-registration-add-registration-database-entities/.gitattributes
+++ b/section-03-registration/03-jobportal-registration-add-registration-database-entities/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-03-registration/04-jobportal-registration-repositories-and-controllers/.gitattributes
+++ b/section-03-registration/04-jobportal-registration-repositories-and-controllers/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-03-registration/05-jobportal-registration-register-new-user/.gitattributes
+++ b/section-03-registration/05-jobportal-registration-register-new-user/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-03-registration/06-jobportal-registration-user-profiles-for-recruiter-and-job-seeker/.gitattributes
+++ b/section-03-registration/06-jobportal-registration-user-profiles-for-recruiter-and-job-seeker/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-03-registration/07-jobportal-registration-add-skills-and-update-profiles/.gitattributes
+++ b/section-03-registration/07-jobportal-registration-add-skills-and-update-profiles/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-04-login-logout/01-job-portal-login-logout-basic-setup/.gitattributes
+++ b/section-04-login-logout/01-job-portal-login-logout-basic-setup/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/.gitattributes
+++ b/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/.gitattributes
+++ b/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/.gitattributes
+++ b/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-04-login-logout/05-job-portal-login-logout-request-mappings/.gitattributes
+++ b/section-04-login-logout/05-job-portal-login-logout-request-mappings/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/.gitattributes
+++ b/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/.gitattributes
+++ b/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/.gitattributes
+++ b/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-06-recruiter-post-new-job/01-recruiter-post-new-job/.gitattributes
+++ b/section-06-recruiter-post-new-job/01-recruiter-post-new-job/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/.gitattributes
+++ b/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/.gitattributes
+++ b/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-08-job-candidate-profile/01-job-candidate-profile/.gitattributes
+++ b/section-08-job-candidate-profile/01-job-candidate-profile/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/.gitattributes
+++ b/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/.gitattributes
+++ b/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-11-download-candidate-resume/01-download-candidate-resume/.gitattributes
+++ b/section-11-download-candidate-resume/01-download-candidate-resume/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/section-12-global-search/01-global-search/.gitattributes
+++ b/section-12-global-search/01-global-search/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf


### PR DESCRIPTION
## Summary
- Adds .gitattributes file to all 23 Maven project directories
- Ensures consistent line ending handling across all projects
- Standardizes configuration for Maven wrapper scripts

## Changes
- Added .gitattributes in all 23 projects

## Configuration
The .gitattributes file configures:
- /mvnw - Unix line endings (LF)
- *.cmd - Windows line endings (CRLF)

This prevents line ending issues with Maven wrapper scripts on different operating systems.

## Verification
All 23 Maven projects now have .gitattributes files.