### PR TITLE
Replace webjars-locator with webjars-locator-lite for Spring Boot 4 compatibility

### DIFF
--- a/section-03-registration/02-jobportal-registration-add-project-template-files/pom.xml
+++ b/section-03-registration/02-jobportal-registration-add-project-template-files/pom.xml
@@ -46,11 +46,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-03-registration/03-jobportal-registration-add-registration-database-entities/pom.xml
+++ b/section-03-registration/03-jobportal-registration-add-registration-database-entities/pom.xml
@@ -67,11 +67,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-03-registration/04-jobportal-registration-repositories-and-controllers/pom.xml
+++ b/section-03-registration/04-jobportal-registration-repositories-and-controllers/pom.xml
@@ -67,11 +67,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-03-registration/05-jobportal-registration-register-new-user/pom.xml
+++ b/section-03-registration/05-jobportal-registration-register-new-user/pom.xml
@@ -67,11 +67,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-03-registration/06-jobportal-registration-user-profiles-for-recruiter-and-job-seeker/pom.xml
+++ b/section-03-registration/06-jobportal-registration-user-profiles-for-recruiter-and-job-seeker/pom.xml
@@ -67,11 +67,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-03-registration/07-jobportal-registration-add-skills-and-update-profiles/pom.xml
+++ b/section-03-registration/07-jobportal-registration-add-skills-and-update-profiles/pom.xml
@@ -67,11 +67,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-04-login-logout/01-job-portal-login-logout-basic-setup/pom.xml
+++ b/section-04-login-logout/01-job-portal-login-logout-basic-setup/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/pom.xml
+++ b/section-04-login-logout/02-job-portal-login-logout-custom-user-authentication-and-authorization/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/pom.xml
+++ b/section-04-login-logout/03-job-portal-login-logout-custom-authentication-success-handler/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/pom.xml
+++ b/section-04-login-logout/04-job-portal-login-logout-security-and-dashboard/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-04-login-logout/05-job-portal-login-logout-request-mappings/pom.xml
+++ b/section-04-login-logout/05-job-portal-login-logout-request-mappings/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/pom.xml
+++ b/section-05-recruiter-profile/01-recruiter-profile-controller-and-service/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/pom.xml
+++ b/section-05-recruiter-profile/02-file-upload-of-recruiter-profile-image/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/pom.xml
+++ b/section-05-recruiter-profile/03-update-dashboard-to-display-recruiter-profile-image/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-06-recruiter-post-new-job/01-recruiter-post-new-job/pom.xml
+++ b/section-06-recruiter-post-new-job/01-recruiter-post-new-job/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/pom.xml
+++ b/section-07-recruiter-dashboard/01-recruiter-dashboard-display-and-retrieve-jobs/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/pom.xml
+++ b/section-07-recruiter-dashboard/02-recruiter-dashboard-edit-a-job/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-08-job-candidate-profile/01-job-candidate-profile/pom.xml
+++ b/section-08-job-candidate-profile/01-job-candidate-profile/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/pom.xml
+++ b/section-09-job-candidate-dashboard-and-apply-for-job/01-job-candidate-dashboard-and-apply-for-job/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/pom.xml
+++ b/section-10-job-candidate-save-a-job/01-job-candidate-save-a-job/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-11-download-candidate-resume/01-download-candidate-resume/pom.xml
+++ b/section-11-download-candidate-resume/01-download-candidate-resume/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->

--- a/section-12-global-search/01-global-search/pom.xml
+++ b/section-12-global-search/01-global-search/pom.xml
@@ -77,11 +77,9 @@
 			<version>3.7.1</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.webjars/webjars-locator -->
 		<dependency>
 			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator</artifactId>
-			<version>0.50</version>
+			<artifactId>webjars-locator-lite</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/font-awesome -->


### PR DESCRIPTION
## Summary
- Replaces deprecated webjars-locator with webjars-locator-lite in all 22 Maven projects
- Ensures Spring Boot 4 (Spring Framework 7) compatibility
- Removes explicit version to use version managed by Spring Boot parent POM

## Changes
- Updated dependency in 22 pom.xml files
- Changed artifactId from webjars-locator to webjars-locator-lite
- Removed explicit version 0.50 (now managed by Spring Boot 4.0.1 parent)
- Removed Maven repository comment

## Rationale
In Spring Framework 7 (used by Spring Boot 4), the legacy WebJars locator org.webjars:webjars-locator has been deprecated.

The older locator relied on classpath scanning, which could negatively affect startup time and memory usage. Spring Framework 7 introduces a newer resolver based on webjars-locator-lite, which avoids classpath scanning and is now the recommended and supported approach.

This update ensures WebJars continue to work correctly in Spring Boot 4 and aligns the project with current Spring best practices.

## Files Modified
All 22 pom.xml files across sections 3-12:
- Section 03: Registration (6 files)
- Section 04: Login/Logout (5 files)
- Section 05: Recruiter Profile (3 files)
- Section 06: Recruiter Post New Job (1 file)
- Section 07: Recruiter Dashboard (2 files)
- Section 08: Job Candidate Profile (1 file)
- Section 09: Job Candidate Dashboard and Apply for Job (1 file)
- Section 10: Job Candidate Save a Job (1 file)
- Section 11: Download Candidate Resume (1 file)
- Section 12: Global Search (1 file)